### PR TITLE
feat: Add --include-sessions flag to export command

### DIFF
--- a/main.go
+++ b/main.go
@@ -51,8 +51,9 @@ type AgentConfig struct {
 }
 
 var (
-	version = "1.0.0"
-	verbose = false
+	version            = "1.0.0"
+	verbose            = false
+	includeSessions    = true
 )
 
 func main() {
@@ -81,6 +82,7 @@ func main() {
 	exportCmd.Flags().StringP("agent", "a", "", "要导出的 Agent ID (必需)")
 	exportCmd.Flags().StringP("output", "o", "", "输出文件路径 (默认：./<agent-id>-agent.tar.gz)")
 	exportCmd.Flags().StringP("openclaw-dir", "d", "", "OpenClaw 目录 (默认：~/.openclaw)")
+	exportCmd.Flags().BoolVar(&includeSessions, "include-sessions", true, "导出时是否包含 sessions (默认：true)")
 	exportCmd.MarkFlagRequired("agent")
 
 	// import 命令标志
@@ -208,6 +210,12 @@ func runExport(cmd *cobra.Command, args []string) error {
 		// 跳过系统文件
 		if shouldSkip(d.Name()) {
 			return nil
+		}
+
+		// 如果不需要 sessions，跳过 sessions 目录
+		if !includeSessions && d.IsDir() && d.Name() == "sessions" {
+			log("  ⊘ 跳过 sessions/ (--include-sessions=false)")
+			return filepath.SkipDir
 		}
 
 		// 跳过目录本身


### PR DESCRIPTION
## 功能说明

添加新的导出参数 `--include-sessions`，允许用户选择是否在导出时包含 sessions 目录。

## 变更内容

- 新增 `--include-sessions` 布尔参数（默认值：true）
- 当设置为 `false` 时，跳过导出 sessions 目录
- 适用于不需要会话历史时减小导出文件大小

## 测试结果

| 模式 | 文件大小 | 文件数 |
|------|---------|--------|
| 包含 sessions (默认) | 64 MB | 342 个 |
| 不包含 sessions | 59 MB | 318 个 |

**节省**：约 5 MB (24 个 sessions 文件)

## 使用示例

```bash
# 默认包含 sessions
./openclaw-agent-cargo export --agent main

# 不包含 sessions
./openclaw-agent-cargo export --agent main --include-sessions=false
```

## 相关问题

Resolves #1